### PR TITLE
Fix need to allow www-data read permissions on user's homedir

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -47,6 +47,7 @@ env.roledefs = {
     'staging': ['ores-staging.eqiad.wmflabs'],
 }
 env.use_ssh_config = True
+env.shell = '/bin/bash -c'
 
 config_dir = '/srv/ores/config'
 venv_dir = '/srv/ores/venv'
@@ -99,8 +100,9 @@ def deploy_web():
 
 @roles('web')
 def update_virtualenv():
-    sr(venv_dir + '/bin/pip', 'install', '--upgrade',
-       '-r', config_dir + '/requirements.txt')
+    with cd(venv_dir):
+        sr(venv_dir + '/bin/pip', 'install', '--upgrade',
+           '-r', config_dir + '/requirements.txt')
 
 
 @roles('staging')


### PR DESCRIPTION
- By default, shell is /bin/bash -c -l, and the -l forces it to
  be a login shell and source your homedirectory stuff, which goes
  haywire when you are attempting to run as www-data. Force shell
  to be just /bin/bash -c to fix this.
- By default, git assumes you have read perms on current directory
  as well, which is problematic for pip install using git. chdir
  to the virtualenv before upating it to fix this problem
