### PR TITLE
Adds /etc/ores/*.yaml to potential config paths

### DIFF
--- a/ores_wsgi.py
+++ b/ores_wsgi.py
@@ -4,10 +4,12 @@ import logging
 import logging.config
 
 import yamlconf
-
 from ores.wsgi import server
 
-config = yamlconf.load(*(open(p) for p in sorted(glob.glob("config/*.yaml"))))
+config_paths = sorted(glob.glob("config/*.yaml") +
+                      glob.glob("/etc/ores/*.yaml"))
+
+config = yamlconf.load(*(open(p) for p in config_paths))
 
 with open("logging_config.yaml") as f:
     logging_config = yamlconf.load(f)


### PR DESCRIPTION
This adds an additional glob in ores_wsgi.py that searches for anything in "/etc/ores/*.yaml".  When nothing is there, you just get an empty list.  

```
$ python
Python 3.4.3 (default, Jul 28 2015, 18:20:59) 
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import glob
>>> glob.glob("/etc/ores/*")
[]
```
